### PR TITLE
signature half direct

### DIFF
--- a/cli.hpp
+++ b/cli.hpp
@@ -461,6 +461,12 @@ struct SimulationConfig {
       snark1_pull,
       "broadcast bitfield instead of snark1",
   }};
+  bool signature_half_direct = false;
+  Args::FlagBool flag_signature_half_direct{{
+      {"--signature-half-direct"},
+      signature_half_direct,
+      "don't send signature to validators",
+  }};
   bool snark1_half_direct = false;
   Args::FlagBool flag_snark1_half_direct{{
       {"--snark1-half-direct"},
@@ -518,6 +524,7 @@ struct SimulationConfig {
              flag_validators_per_group,
              flag_shuffle,
              flag_snark1_pull,
+             flag_signature_half_direct,
              flag_snark1_half_direct,
              flag_signature_direct,
              flag_local_aggregation_only,
@@ -566,6 +573,7 @@ struct SimulationConfig {
     yaml.at({"topology"}).get(topology, enum_topology_);
     yaml.at({"shuffle"}).get(shuffle);
     yaml.at({"snark1_pull"}).get(snark1_pull);
+    yaml.at({"signature_half_direct"}).get(signature_half_direct);
     yaml.at({"snark1_half_direct"}).get(snark1_half_direct);
     yaml.at({"signature_direct"}).get(signature_direct);
 

--- a/src/beamsim/example/roles.hpp
+++ b/src/beamsim/example/roles.hpp
@@ -24,6 +24,7 @@ namespace beamsim::example {
       std::vector<PeerIndex> validators;
       IndexOfPeerMap index_of_validators;
       std::vector<PeerIndex> local_aggregators;
+      IndexOfPeerMap index_of_local_aggregators;
     };
     PeerIndex validator_count;
     std::vector<Group> groups;
@@ -66,7 +67,10 @@ namespace beamsim::example {
       for (PeerIndex peer_index = 0; peer_index < local_aggregator_count;
            ++peer_index) {
         GroupIndex group_index = peer_index % config.group_count;
-        roles.groups.at(group_index).local_aggregators.emplace_back(peer_index);
+        auto &group = roles.groups.at(group_index);
+        group.index_of_local_aggregators.emplace(
+            peer_index, group.local_aggregators.size());
+        group.local_aggregators.emplace_back(peer_index);
       }
       for (PeerIndex peer_index = local_aggregator_count;
            peer_index < aggregator_count;


### PR DESCRIPTION
With `--signature-half-direct` (like `--snark1-half-direct`) validator outside of grid/gossip sends signature directly to grid/gossip member, so that non-aggregators never receive unnecessary signature from other validators.